### PR TITLE
data_controllers should be a function.

### DIFF
--- a/src/Provider/SaxulumWebProfilerProvider.php
+++ b/src/Provider/SaxulumWebProfilerProvider.php
@@ -47,7 +47,7 @@ class SaxulumWebProfilerProvider implements ServiceProviderInterface
             $app['data_collectors'] = $app->extend('data_collectors',
                 $app->share(function(array $collectors) use ($app) {
                     if(isset($app['doctrine'])) {
-                        $collectors['db'] = $app['saxulum.orm.datacolletor'];
+                        $collectors['db'] = function ($app) { $app['saxulum.orm.datacolletor']; };
                     }
 
                     if(isset($app['doctrine_mongodb'])) {
@@ -60,7 +60,7 @@ class SaxulumWebProfilerProvider implements ServiceProviderInterface
                             }
                         ));
 
-                        $collectors['mongodb'] = $app['saxulum.mongodb.odm.datacolletor'];
+                        $collectors['mongodb'] = function ($app) { return $app['saxulum.mongodb.odm.datacolletor']; };
                     }
 
                     return $collectors;
@@ -68,7 +68,7 @@ class SaxulumWebProfilerProvider implements ServiceProviderInterface
             ));
 
             $app['data_collector.templates'] = $app->extend('data_collector.templates',
-                $app->share(function(Application $app, array $dataCollectorTemplates) {
+                $app->share(function(array $dataCollectorTemplates) use ($app) {
                     if(isset($app['doctrine'])) {
                         $dataCollectorTemplates[] = array('db', '@SaxulumWebProfilerProvider/Collector/db.html.twig');
                     }


### PR DESCRIPTION
Hello.

I found the problem.
Please confirm.


An error will occur at execution of the data_controller.

Error massage: Error: Function name must be a string
Occured location: https://github.com/silexphp/Silex-WebProfiler/blob/master/WebProfilerServiceProvider.php#L239

----

And `$app->share(function)` arguments error occurs.

Error message: Catchable Fatal Error: Argument 1 passed
